### PR TITLE
alternate heading control

### DIFF
--- a/src/main/java/frc/lib/util/COTSTalonFXSwerveConstants.java
+++ b/src/main/java/frc/lib/util/COTSTalonFXSwerveConstants.java
@@ -286,7 +286,7 @@ public class COTSTalonFXSwerveConstants {
                 /** (150 / 7) : 1 */
                 double angleGearRatio = ((150.0 / 7.0) / 1.0);
         
-                double angleKP = 1.0; //I think this is it, im setting this higher. This value is untestested and is consistent across every kraken
+                double angleKP = 10.0; //I think this is it, im setting this higher. This value is untestested and is consistent across every kraken
                 double angleKI = 0.0;
                 double angleKD = 0.0;
         

--- a/src/main/java/frc/robot/CTREConfigs.java
+++ b/src/main/java/frc/robot/CTREConfigs.java
@@ -36,7 +36,7 @@ public final class CTREConfigs {
 
         /** Swerve Drive Motor Configuration */
         /* Motor Inverts and Neutral Mode */
-        swerveDriveFXConfig.MotorOutput.Inverted = Constants.Swerve.driveMotorInvert;// the drive motors work just fine 
+        swerveDriveFXConfig.MotorOutput.Inverted = Constants.Swerve.driveMotorInvert;
         swerveDriveFXConfig.MotorOutput.NeutralMode = Constants.Swerve.driveNeutralMode;
 
         /* Gear Ratio Config */ //the gear ratio is fine (150/7)/6 im pretty sure

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -22,11 +22,11 @@ public final class Constants {
         public static final int pigeonID = 1;
 
         public static final COTSTalonFXSwerveConstants chosenModule =  //TODO: This must be tuned to specific robot
-        COTSTalonFXSwerveConstants.SDS.MK4i.KrakenX60(COTSTalonFXSwerveConstants.SDS.MK4i.driveRatios.L1);
+        COTSTalonFXSwerveConstants.SDS.MK4i.KrakenX60(COTSTalonFXSwerveConstants.SDS.MK4i.driveRatios.L3);
 
         /* Drivetrain Constants */
-        public static final double trackWidth = Units.inchesToMeters(21.73); //TODO: This must be tuned to specific robot
-        public static final double wheelBase = Units.inchesToMeters(21.73); //TODO: This must be tuned to specific robot
+        public static final double trackWidth = Units.inchesToMeters(29); //TODO: This must be tuned to specific robot
+        public static final double wheelBase = Units.inchesToMeters(29); //TODO: This must be tuned to specific robot
         public static final double wheelCircumference = chosenModule.wheelCircumference;
 
         /* Swerve Kinematics 
@@ -69,6 +69,7 @@ public final class Constants {
         public static final double closedLoopRamp = 0.0;
 
         /* Angle Motor PID Values */
+        //This PID controller gets the motors to the 45 degrees we wamt
         public static final double angleKP = chosenModule.angleKP;
         public static final double angleKI = chosenModule.angleKI;
         public static final double angleKD = chosenModule.angleKD;
@@ -78,6 +79,11 @@ public final class Constants {
         public static final double driveKI = 0.0;
         public static final double driveKD = 0.0;
         public static final double driveKF = 0.0;
+
+        /*Robot Heading PID Control */
+        public static final double headingKP = 0;
+        public static final double headingKI = 0;
+        public static final double headingKD = 0;
 
         /* Drive Motor Characterization Values From SYSID */
         public static final double driveKS = 0.32; //TODO: This must be tuned to specific robot
@@ -99,10 +105,10 @@ public final class Constants {
         /* Module Specific Constants */
         /* Front Left Module - Module 0 */
         public static final class Mod0 { //TODO: This must be tuned to specific robot
-            public static final int driveMotorID = 1;
-            public static final int angleMotorID = 2;
-            public static final int canCoderID = 1;
-            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(0.0);
+            public static final int driveMotorID = 8;
+            public static final int angleMotorID = 7;
+            public static final int canCoderID = 12;
+            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(-2.5488); // -.007080
             public static final SwerveModuleConstants constants = 
                 new SwerveModuleConstants(driveMotorID, angleMotorID, canCoderID, angleOffset);
         }
@@ -111,8 +117,8 @@ public final class Constants {
         public static final class Mod1 { //TODO: This must be tuned to specific robot
             public static final int driveMotorID = 1; //programmed in a circle
             public static final int angleMotorID = 2;
-            public static final int canCoderID = 2;
-            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(0.0);
+            public static final int canCoderID = 9;
+            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(-156.09394); // -.433594
             public static final SwerveModuleConstants constants = 
                 new SwerveModuleConstants(driveMotorID, angleMotorID, canCoderID, angleOffset);
         }
@@ -121,18 +127,18 @@ public final class Constants {
         public static final class Mod2 { //TODO: This must be tuned to specific robot
             public static final int driveMotorID = 5;
             public static final int angleMotorID = 6;
-            public static final int canCoderID = 3;
-            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(0.0);
+            public static final int canCoderID = 11;
+            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(-3.42756); //-.009521
             public static final SwerveModuleConstants constants = 
                 new SwerveModuleConstants(driveMotorID, angleMotorID, canCoderID, angleOffset);
         }
 
         /* Back Right Module - Module 3 */
         public static final class Mod3 { //TODO: This must be tuned to specific robot
-            public static final int driveMotorID = 7;
-            public static final int angleMotorID = 8;
-            public static final int canCoderID = 4;
-            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(0.0);
+            public static final int driveMotorID = 4;
+            public static final int angleMotorID = 3;
+            public static final int canCoderID = 10;
+            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(-188.52); //-.523682
             public static final SwerveModuleConstants constants = 
                 new SwerveModuleConstants(driveMotorID, angleMotorID, canCoderID, angleOffset);
         }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -35,7 +35,7 @@ public class Robot extends TimedRobot {
     m_robotContainer = new RobotContainer();
 
     //this will be the object used to generate all of the autonomous paths 
-    autoObject = new Auto(m_robotContainer.getSwerveObject(), m_robotContainer);
+    //autoObject = new Auto(m_robotContainer.getSwerveObject(), m_robotContainer);
 
     //Creates a sendable chooser with all of the paths/loads all of the autos to be used pre emptively
     //This will contain both the pathplanner autos and autos that I've made with combinations between the two
@@ -75,7 +75,7 @@ public class Robot extends TimedRobot {
   /** This autonomous runs the autonomous command selected by your {@link RobotContainer} class. */
   @Override
   public void autonomousInit() {
-    m_autonomousCommand = autoObject.getAutonomousCommand();
+    m_autonomousCommand = m_robotContainer.getAutonomousCommand();
 
     
     //m_autonomousCommand = m_robotContainer.getAutonomousCommand();

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -29,7 +29,8 @@ public class RobotContainer {
     /* Drive Controls */
     private final int translationAxis = XboxController.Axis.kLeftY.value;
     private final int strafeAxis = XboxController.Axis.kLeftX.value;
-    private final int rotationAxis = XboxController.Axis.kRightX.value;
+    private final int rotationAxisX = XboxController.Axis.kRightX.value;
+    private final int rotationAxisY = XboxController.Axis.kRightY.value;
 
     /* Driver Buttons */
     private final JoystickButton zeroGyro = new JoystickButton(operator, XboxController.Button.kY.value);
@@ -53,7 +54,8 @@ public class RobotContainer {
                 s_Swerve, 
                 () -> -driver.getRawAxis(translationAxis), //this part works, wheels spin forwards and backwards
                 () -> -driver.getRawAxis(strafeAxis), //the wheels will turn 90 degrees to strafe
-                () -> -driver.getRawAxis(rotationAxis), //the wheels will turn either 45 degrees or if strafe/translation is active a combined vector
+                () -> -driver.getRawAxis(rotationAxisX), //the wheels will turn either 45 degrees or if strafe/translation is active a combined vector
+                () -> -driver.getRawAxis(rotationAxisY), //Using two 
                 () -> robotCentric.getAsBoolean() //this is set by the driver, do they want forward dependent on the robot heading or the 
                                                  //pre set forward direction like postive x or something
             )
@@ -72,7 +74,7 @@ public class RobotContainer {
     private void configureButtonBindings() {
         /* Driver Buttons */
         zeroGyro.onTrue(new InstantCommand(() -> s_Swerve.zeroHeading()));
-        aButton.onTrue(new levelOneArm(arm));
+        //aButton.onTrue(new levelOneArm(arm));
 
     }
 

--- a/src/main/java/frc/robot/SwerveModule.java
+++ b/src/main/java/frc/robot/SwerveModule.java
@@ -11,6 +11,7 @@ import edu.wpi.first.math.controller.SimpleMotorFeedforward;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
+import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.lib.math.Conversions;
 import frc.lib.util.SwerveModuleConstants;
@@ -39,9 +40,7 @@ public class SwerveModule {
     public SwerveModule(int moduleNumber, SwerveModuleConstants moduleConstants){
         this.moduleNumber = moduleNumber;
         this.angleOffset = moduleConstants.angleOffset;
-        //Should create a canbus object to pass onto the TalonFx objects in the SwerveModule 
-        //have to figure out the name of the canivore
-        CANBus canbus = new CANBus("PLACE HOLDER");
+        //CanBus is set in the motorController constructors
         
         /* Angle Encoder Config */
         angleEncoder = new CANcoder(moduleConstants.cancoderID);
@@ -51,6 +50,7 @@ public class SwerveModule {
         /* Angle Motor Config */
         mAngleMotor = new TalonFX(moduleConstants.angleMotorID);
         mAngleMotor.getConfigurator().apply(Robot.ctreConfigs.swerveAngleFXConfig); //The threshold and the threshold time no longer exist
+        Timer.delay(.05); //This might help with wheels not aligning after setting offsets
         resetToAbsolute(); //resets the angle encoders
 
         /* Drive Motor Config */
@@ -66,8 +66,7 @@ public class SwerveModule {
     //Open loop basically means that the motor that sets the speed of the wheel/bot 
     //operates without the known position of the wheel
     public void setDesiredState(SwerveModuleState desiredState, boolean isOpenLoop){
-        desiredState = SwerveModuleState.optimize(desiredState, getState().angle); //angle of the wheel is optimized, im guessig its just a new object\
-                                                                                   //with a seperate memory address
+        desiredState = SwerveModuleState.optimize(desiredState, getState().angle); //angle of the wheel is optimized
         mAngleMotor.setControl(anglePosition.withPosition(desiredState.angle.getRotations())); //this sets the angle, feed forward makes sure it has the voltage
                                                                                                //to move the right distance
         setSpeed(desiredState, isOpenLoop); //the drive motor has yet to set the speed of the motor
@@ -93,7 +92,7 @@ public class SwerveModule {
     }
 
     public void resetToAbsolute(){
-        double absolutePosition = getCANcoder().getRotations() - angleOffset.getRotations(); //magnetic encoders ARE absolute encoders so this is curious
+        double absolutePosition = getCANcoder().getRotations() - angleOffset.getRotations(); //This is what fixes the position of the wheels
         mAngleMotor.setPosition(absolutePosition); 
     }
 

--- a/src/main/java/frc/robot/autos/exampleAuto.java
+++ b/src/main/java/frc/robot/autos/exampleAuto.java
@@ -31,7 +31,7 @@ public class exampleAuto extends SequentialCommandGroup {
                 // Start at the origin facing the +X direction
                 new Pose2d(0, 0, new Rotation2d(0)),
                 // Pass through these two interior waypoints, making an 's' curve path
-                List.of(new Translation2d(1, 1), new Translation2d(2, -1)),
+                List.of(new Translation2d(1, 0), new Translation2d(2, 0)),
                 // End 3 meters straight ahead of where we started, facing forward
                 new Pose2d(3, 0, new Rotation2d(0)),
                 config);

--- a/src/main/java/frc/robot/commands/TeleopSwerve.java
+++ b/src/main/java/frc/robot/commands/TeleopSwerve.java
@@ -9,6 +9,9 @@ import java.util.function.DoubleSupplier;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj2.command.Command;
+
+import edu.wpi.first.math.controller.ProfiledPIDController;
+import edu.wpi.first.math.trajectory.TrapezoidProfile;
 //I'll have to see if this defualt command has to be canceled 
 //When autos in teleop are ran. Since the s_Swerve subsystem will have to be
 //used 
@@ -18,18 +21,44 @@ public class TeleopSwerve extends Command {
     private Swerve s_Swerve;    
     private DoubleSupplier translationSup;
     private DoubleSupplier strafeSup;
-    private DoubleSupplier rotationSup;
+    private DoubleSupplier rotationSupX;
     private BooleanSupplier robotCentricSup;
+    private DoubleSupplier rotationSupY;
+
+    private ProfiledPIDController headingController;
                                                         //forward and back          side to side                 rotates the robot by setting wheel angle
-    public TeleopSwerve(Swerve s_Swerve, DoubleSupplier translationSup, DoubleSupplier strafeSup, DoubleSupplier rotationSup, BooleanSupplier robotCentricSup) {
+    public TeleopSwerve(Swerve s_Swerve, DoubleSupplier translationSup, DoubleSupplier strafeSup, DoubleSupplier rotationSupX, DoubleSupplier rotationSupY, BooleanSupplier robotCentricSup) {
         this.s_Swerve = s_Swerve; //a weird circular depency going on here with the object using this default command 
                                   // also being in the default.... code runs though
         addRequirements(s_Swerve);
 
         this.translationSup = translationSup;
         this.strafeSup = strafeSup;
-        this.rotationSup = rotationSup;
+        this.rotationSupX = rotationSupX;
+        this.rotationSupY = rotationSupY;
         this.robotCentricSup = robotCentricSup;
+
+        //Change the HeadingController trapezoid constraints
+        headingController = new ProfiledPIDController(Constants.Swerve.headingKP, Constants.Swerve.headingKI, Constants.Swerve.headingKD, new TrapezoidProfile.Constraints(2, 1));
+
+    }
+
+    @Override
+    public void initialize() { 
+        headingController.enableContinuousInput(-Math.PI, Math.PI);
+    }
+    //This command is intended to be used with joySticks and will do angle calculations for you
+    public double robotHeading() { 
+        double rotationValX = MathUtil.applyDeadband(rotationSupX.getAsDouble(), Constants.stickDeadband);
+        double rotationValY = MathUtil.applyDeadband(rotationSupY.getAsDouble(), Constants.stickDeadband);
+
+        //magnitude is intended to speeds up the turning speed
+        double magnitudeOfRotation = Math.pow(rotationValX, 2) + Math.pow(rotationValY, 2);
+        double angleDegrees = Math.atan(rotationValY/rotationValX);
+
+        double rotationVal = headingController.calculate(s_Swerve.getHeading().getDegrees(), angleDegrees);
+
+        return rotationVal;
     }
 
     @Override
@@ -37,7 +66,7 @@ public class TeleopSwerve extends Command {
         /* Get Values, Deadband*/
         double translationVal = MathUtil.applyDeadband(translationSup.getAsDouble(), Constants.stickDeadband);
         double strafeVal = MathUtil.applyDeadband(strafeSup.getAsDouble(), Constants.stickDeadband);
-        double rotationVal = MathUtil.applyDeadband(rotationSup.getAsDouble(), Constants.stickDeadband);
+        double rotationVal = robotHeading();
        //makes sure no drift
         /* Drive */
         s_Swerve.drive( //calls drive function of swerve object

--- a/src/main/java/frc/robot/subsystems/Arm.java
+++ b/src/main/java/frc/robot/subsystems/Arm.java
@@ -208,8 +208,10 @@ public class Arm extends SubsystemBase{
 
     }
 
-    public boolean withinBounds() {
-
+    public boolean armWithinBounds() {
+        if (Math.abs(ArmConstants.maxiRotatArm - armHingeEncoderL.getPosition()) <= .10) {
+            
+        }
 
         return false;
     }

--- a/src/main/java/frc/robot/subsystems/Swerve.java
+++ b/src/main/java/frc/robot/subsystems/Swerve.java
@@ -33,8 +33,7 @@ public class Swerve extends SubsystemBase {
         gyro = new Pigeon2(Constants.Swerve.pigeonID);
         gyro.getConfigurator().apply(new Pigeon2Configuration());
         gyro.setYaw(0); //the pigeons values arent used for anything right now
-        int fella = 1;
-        int otherFella = 1;
+    
         
         //this object is used at the end of the drive method 
         mSwerveMods = new SwerveModule[] {
@@ -58,9 +57,9 @@ public class Swerve extends SubsystemBase {
                                     translation.getX(),   //Seems like what would serve as a change in X and Y              //this is a static function and it's unknown where these values are stored 
                                     translation.getY(),   //Are actually just speed values. dx/dt, dy/dt essentially
                                     rotation, //dtheta/dt, the change is radians per unit of time
-                                    getHeading()// fromFieldRelativeSpeeds create a chassisspeeds object that is robotrelaitve
+                                    getHeading()// field relative
                                 )
-                                : new ChassisSpeeds( //this creates a fieldrelative chassisspeeds object
+                                : new ChassisSpeeds( //not field relative
                                     translation.getX(), 
                                     translation.getY(), 
                                     rotation)
@@ -68,6 +67,12 @@ public class Swerve extends SubsystemBase {
         SwerveDriveKinematics.desaturateWheelSpeeds(swerveModuleStates, Constants.Swerve.maxSpeed); //normalizes wheel speeds, wheels arent spinning yet
                                                                                                     //this calculation is done before the value is pushed to
                                                                                                     //motors
+        //These modules are spinning in the opposite direction usually
+        //I'm reversing the direction of the speed they spin in the correct direction
+        //For some reason it is only on the right side
+        swerveModuleStates[1].speedMetersPerSecond *= -1;
+        swerveModuleStates[3].speedMetersPerSecond *= -1;
+
                                 //here is the object being used, mod temporarily represents each swerve module
         for(SwerveModule mod : mSwerveMods){ //a python style for loop that just iterates through 1 by 1
             mod.setDesiredState(swerveModuleStates[mod.moduleNumber], isOpenLoop); //it passes a temporary object swerveModuleStates which are replaced upon the next input read


### PR DESCRIPTION
This is an alternate way to control the heading of the robot via the joysticks. 
Instead of giving a direction and magnitude of turning the robot will now point in whatever direction 
that the driver points at with the joystick.